### PR TITLE
SS-160: Harvester component reporting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,10 @@ MONGO_URL=mongodb://jstorforumro:
 MONGO_DBNAME=jstorforumro
 MONGO_COLLECTION=jstorforum-dev
 MONGO_COLLECTION_ITEST=integration_test
+HARVEST_COLLECTON=jstor_harvests
+REPOSITORY_COLLECTION=jstor_repositories 
+RECORD_COLLECTION=jstor_records
+
+aspace_oai_url=
+jstor_oai_url=http://oai.forum.jstor.org/oai/
+jstor_harvest_dir=/tmp/harvested

--- a/app/jstor_harvester.py
+++ b/app/jstor_harvester.py
@@ -6,7 +6,7 @@ from random import randint
 from time import sleep
 from pymongo import MongoClient
 from sickle import Sickle
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 
 class JstorHarvester():
     def __init__(self):
@@ -16,6 +16,7 @@ class JstorHarvester():
         self.parent_job_ticket_id = None
         self.child_error_count = 0
         self.max_child_errors = int(os.getenv("CHILD_ERROR_LIMIT", 10))
+        self.repositories = self.load_repositories()
 
     # Write to error log update result and update job tracker file
     def handle_errors(self, result, error_msg, exception_msg = None, set_job_failed = False):
@@ -47,6 +48,10 @@ class JstorHarvester():
         current_app.logger.info("Sleep " + str(sleep_s) + " seconds")
         sleep(sleep_s)
 
+        job_ticket_id = str(request_json['job_ticket_id'])
+        if job_ticket_id == None:
+            job_ticket_id = '999999999'
+
         harvestdate = date.today() - timedelta(days = 1)
         if 'harvesttype' in request_json:
             if request_json["harvesttype"] == "full":
@@ -60,14 +65,14 @@ class JstorHarvester():
             current_app.logger.info("running jstorforum harvest")
             jstorforum = request_json['jstorforum']
         if jstorforum:
-            self.do_harvest('jstorforum', harvestdate, "harvestjobs.json")
+            self.do_harvest('jstorforum', harvestdate, "harvestjobs.json", job_ticket_id)
 
         aspace = False
         if 'aspace' in request_json:
             current_app.logger.info("running aspace harvest")
             aspace = request_json['aspace']
         if aspace:
-            self.do_harvest('aspace', harvestdate,  "harvestjobs.json")
+            self.do_harvest('aspace', harvestdate,  "harvestjobs.json", job_ticket_id)
 
         #integration test: write small record to mongo to prove connectivity
         integration_test = False
@@ -75,9 +80,9 @@ class JstorHarvester():
             integration_test = request_json['integration_test']
         if (integration_test):
             current_app.logger.info("running integration mongo test")
-            self.do_harvest('jstorforum', None,  "harvestjobs_test.json")
+            self.do_harvest('jstorforum', None,  "harvestjobs_test.json", job_ticket_id)
             #to do - make aspace date configurable, from and until
-            self.do_harvest('aspace', '2023-02-06',  "harvestjobs_test.json")
+            self.do_harvest('aspace', '2023-02-06',  "harvestjobs_test.json", job_ticket_id)
             try:
                 mongo_url = os.environ.get('MONGO_URL')
                 mongo_dbname = os.environ.get('MONGO_DBNAME')
@@ -86,7 +91,6 @@ class JstorHarvester():
 
                 mongo_db = mongo_client[mongo_dbname]
                 integration_collection = mongo_db[mongo_collection]
-                job_ticket_id = str(request_json['job_ticket_id'])
                 test_id = "harvester-" + job_ticket_id
                 test_record = { "id": test_id, "status": "inserted" }
                 integration_collection.insert_one(test_record)
@@ -99,19 +103,36 @@ class JstorHarvester():
         result['message'] = 'Job ticket id {} has completed '.format(request_json['job_ticket_id'])
         return result
 
-    def do_harvest(self, jobname, harvestdate, configfile):
+    def do_harvest(self, jobname, harvestdate, configfile, job_ticket_id):
 
         with open(configfile) as f:
             harvjobsjson = f.read()
         harvestconfig = json.loads(harvjobsjson)
         #current_app.logger.debug("harvestconfig")        
-        #current_app.logger.debug(harvestconfig) 
+        #current_app.logger.debug(harvestconfig)
+        mongo_url = os.environ.get('MONGO_URL')
+        mongo_dbname = os.environ.get('MONGO_DBNAME')
+        harvest_collection_name = os.environ.get('HARVEST_COLLECTION', 'jstor_harvests')
+        repository_collection_name = os.environ.get('REPOSITORY_COLLECTION', 'jstor_repositories')
+        record_collection_name = os.environ.get('RECORD_COLLECTION', 'jstor_records')
+        mongo_url = os.environ.get('MONGO_URL')
+        mongo_client = None
+        mongo_db = None
+        try:
+            mongo_client = MongoClient(mongo_url, maxPoolSize=1)
+            mongo_db = mongo_client[mongo_dbname]
+        except Exception as err:
+            current_app.logger.error("Error: unable to connect to mongodb, {}", err)
+                                                                                              
+
         harvestDir = os.getenv("jstor_harvest_dir") + "/"        
         for job in harvestconfig:     
             if jobname == 'jstorforum' and jobname == job["jobName"]:   
                 for set in job["harvests"]["sets"]:
                     setSpec = "{}".format(set["setSpec"])
+                    repository_name = self.repositories[setSpec]
                     opDir = set["opDir"]
+                    totalHarvestCount = 0
                     if not os.path.exists(harvestDir + opDir + "_oaiwrapped"):
                         os.makedirs(harvestDir + opDir + "_oaiwrapped")
                     current_app.logger.info("Harvesting set:" + setSpec + ", output dir: " + opDir)
@@ -120,38 +141,139 @@ class JstorHarvester():
                         if harvestdate == None:
                             records = sickle.ListRecords(metadataPrefix='oai_ssio', set=setSpec)
                         else:
-                            records = sickle.ListRecords(**{'metadataPrefix':'oai_ssio', 'from':harvestdate, 'set':setSpec})     
+                            records = sickle.ListRecords(**{'metadataPrefix':'oai_ssio', 
+                                'from':harvestdate, 'set':setSpec})
                         for item in records:
                             current_app.logger.info(item.header.identifier)
                             with open(harvestDir + opDir + "_oaiwrapped/" + item.header.identifier + ".xml", "w") as f:
                                 f.write(item.raw)
+                            #add record to mongo
+                            try:
+                                status = "add"
+                                self.write_record(job_ticket_id, item.header.identifier, harvestdate, setSpec, repository_name, 
+                                    status, record_collection_name, mongo_db)
+                                totalHarvestCount = totalHarvestCount + 1    
+                            except Exception as e:
+                                current_app.logger.error(e)
+                                current_app.logger.error("Mongo error writing " + setSpec + " record: " +  item.header.identifier)
                     except Exception as e:
                         #to do: use narrower exception for NoRecordsMatch
-                        current_app.logger.info(e)
-                        current_app.logger.info("No records for: " + setSpec + ", output dir: " + opDir)
+                        current_app.logger.error(e)
+                        current_app.logger.error("No records for: " + setSpec + ", output dir: " + opDir)
+                    try:
+                        self.write_harvest(job_ticket_id, harvestdate, setSpec, 
+                            repository_name, totalHarvestCount, harvest_collection_name, mongo_db)
+                    except Exception as e:
+                        current_app.logger.error(e)
+                        current_app.logger.error("Mongo error writing harvest record for : " +  setSpec)
+
             if jobname == 'aspace' and jobname == job["jobName"]:  
                 ns = {'ead': 'urn:isbn:1-931666-22-9'}
                 sickle = Sickle(os.getenv("aspace_oai_url"))
                 if not os.path.exists(harvestDir + 'aspace'):
                     os.makedirs(harvestDir + 'aspace')
+                totalAspaceHarvestCount = 0
                 try:    
                     if harvestdate == None:    
                         records = sickle.ListRecords(metadataPrefix='oai_ead')
                     else:    
                         if configfile == 'harvestjobs_test.json':
-                            records = sickle.ListRecords(**{'metadataPrefix':'oai_ead', 'from':harvestdate, 'until': harvestdate + timedelta(days = 1)})
+                            harvest_date_obj = datetime.strptime(harvestdate, 
+                                "%Y-%m-%d")  + timedelta(days = 1)
+                            records = sickle.ListRecords(**{'metadataPrefix':'oai_ead', 'from':harvestdate, 
+                                'until': harvest_date_obj.strftime("%Y-%m-%d") })
                         else:
                             records = sickle.ListRecords(**{'metadataPrefix':'oai_ead', 'from':harvestdate})
                     for item in records:
                         current_app.logger.info(item.header.identifier)
                         eadid = item.xml.xpath("//ead:eadid", namespaces=ns)[0].text
+                        totalAspaceHarvestCount = totalAspaceHarvestCount + 1
 
                         with open(harvestDir + "aspace/" + eadid + ".xml", "w") as f:
                             f.write(item.raw)
+                        #add record to mongo
+                        try:
+                            status = "add"
+                            self.write_record(job_ticket_id, item.header.identifier, harvestdate, "0000", "aspace", 
+                                status, record_collection_name, mongo_db)
+                        except Exception as e:
+                                current_app.logger.error(e)
+                                current_app.logger.error("Mongo error writing aspace record: " + eadid)
                 except Exception as e:
                     #to do: use narrower exception for NoRecordsMatch
                     current_app.logger.info(e)
                     current_app.logger.info("No records for aspace" )
+
+                try:
+                    self.write_harvest(job_ticket_id, harvestdate, "0000", "aspace", 
+                        totalAspaceHarvestCount, harvest_collection_name, mongo_db)
+                except Exception as e:
+                    current_app.logger.error(e)
+                    current_app.logger.error("Mongo error writing harvest record for : aspace")
+
+        if (mongo_client is not None):            
+            mongo_client.close()
+
+    def write_harvest(self, harvest_id, harvest_date, repository_id, repository_name,
+            total_harvested, collection_name, mongo_db):
+        if mongo_db == None:
+            current_app.logger.info("Error: mongo db not instantiated")
+            return
+        try:
+            if harvest_date == None: #set harvest date to today if harvest date is None
+                harvest_date = datetime.today().strftime('%Y-%m-%d') 
+            harvest_date_obj = datetime.strptime(harvest_date, "%Y-%m-%d")
+            harvest_record = { "id": harvest_id, "harvest_date": harvest_date_obj, 
+                "repository_id": repository_id, "repository_name": repository_name, 
+                "total_harvest_count": total_harvested, "success": False }
+            harvest_collection = mongo_db[collection_name]
+            harvest_collection.insert_one(harvest_record)
+            current_app.logger.info(repository_name + " harvest for " + harvest_date + " written to mongo ")
+        except Exception as err:
+            current_app.logger.info("Error: unable to connect to mongodb, {}", err)
+        return
+
+    def write_record(self, harvest_id, record_id, harvest_date, repository_id, repository_name,
+            status, collection_name, mongo_db):
+        if mongo_db == None:
+            current_app.logger.info("Error: mongo db not instantiated")
+            return
+        try:
+            if harvest_date == None: #set harvest date to today if harvest date is None
+                harvest_date = datetime.today().strftime('%Y-%m-%d')  
+            harvest_date_obj = datetime.strptime(harvest_date, "%Y-%m-%d")
+            harvest_record = { "id": harvest_id, "last_update": harvest_date_obj, "record_id": record_id, 
+                "repository_id": repository_id, "repository_name": repository_name, 
+                "status": status, "harvested": True, "transformed": False, "published": False }
+            record_collection = mongo_db[collection_name]
+            record_collection.insert_one(harvest_record)
+            current_app.logger.info("record " + str(record_id) + " of repo " + str(repository_id) + " written to mongo ")
+        except Exception as err:
+            current_app.logger.info("Error: unable to connect to mongodb, {}", err)
+        return
+
+    def load_repositories(self):
+        repositories = {}
+        try:
+            mongo_url = os.environ.get('MONGO_URL')
+            mongo_dbname = os.environ.get('MONGO_DBNAME')
+            repository_collection_name = os.environ.get('REPOSITORY_COLLECTION', 'jstor_repositories')
+            mongo_url = os.environ.get('MONGO_URL')
+            mongo_dbname = os.environ.get('MONGO_DBNAME')
+            mongo_client = MongoClient(mongo_url, maxPoolSize=1)
+
+            mongo_db = mongo_client[mongo_dbname]
+            repository_collection = mongo_db[repository_collection_name]
+            repos = repository_collection.find({})
+            for r in repos:
+                k = r["_id"]
+                v = r["displayname"]
+                repositories[k] = v 
+            mongo_client.close()
+            return repositories
+        except Exception as err:
+            current_app.logger.info("Error: unable to load repository table from mongodb, {}", err)
+            return repositories
 
     def revert_task(self, job_ticket_id, task_name):
         return True


### PR DESCRIPTION
**SS-160: Harvester component reporting**
* * *

**JIRA Ticket**: https://jira.huit.harvard.edu/browse/SS-160

# What does this Pull Request do?
pushes harvested record info to mongo

# How should this be tested?

download and run locally:
1) copy .env-example to .env   
2) in the env file, set `aspace_oai_url` to  http://ltsds-cloud-qa-1.lib.harvard.edu:19124/oai/  and `MONGO_URL` to the dev instance in the JSTOR lastpass vault
3) mkdir /tmp/harvested
4) start container `docker-compose -f docker-compose-local.yml up -d --build --force-recreate `    also you will have to spin up the itest container locally too as well. ideally all of the pipeline should be up, but for this test, itest and this container should do.
5) start the itest locally with the  `curl -k "https://localhost:25003/integration"` command. 
6) In another shell, `docker exec -it jstor-harvester bash` to go into the current container and then `cd ogs/jstor_harvester/<CONTAINER_ID>` and live tail the console log
7) you should see output in the console log that looks like this:

{"event": "**************JStor Harvester: Do Task**************", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:47.852866Z"}
{"event": "WORKER NUMBER None", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:47.857462Z"}
{"event": "Sleep 1 seconds", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:47.858764Z"}
{"event": "running integration mongo test", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:48.861874Z"}
{"event": "Harvesting set:713, output dir: warren_test", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:48.874229Z"}
{"event": "8000245134", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.272309Z"}
{"event": "record 8000245134 of repo 713 written to mongo ", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.513546Z"}
{"event": "8000245135", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.515954Z"}
{"event": "record 8000245135 of repo 713 written to mongo ", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.555760Z"}
{"event": "8000245136", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.558151Z"}
{"event": "record 8000245136 of repo 713 written to mongo ", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.605727Z"}
{"event": "8000245137", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.607683Z"}
{"event": "record 8000245137 of repo 713 written to mongo ", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.655562Z"}
{"event": "8000245138", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.657251Z"}
{"event": "record 8000245138 of repo 713 written to mongo ", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.705649Z"}
{"event": "8000245139", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.707688Z"}
{"event": "record 8000245139 of repo 713 written to mongo ", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.755774Z"}
{"event": "8000245140", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.757548Z"}
{"event": "record 8000245140 of repo 713 written to mongo ", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.805823Z"}
{"event": "8000245141", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.807827Z"}
{"event": "record 8000245141 of repo 713 written to mongo ", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.855698Z"}
{"event": "Countway: Warren Anatomical harvest for 2023-02-22 written to mongo ", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:53.905891Z"}
{"event": "The combination of the values of the from, until, set and metadataPrefix arguments results in an empty list.", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:54.322327Z"}
{"event": "No records for aspace", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:54.323407Z"}
{"event": "aspace harvest for 2023-02-06 written to mongo ", "logger": "app", "level": "info", "timestamp": "2023-02-22T22:36:54.524268Z"}
{"event": "127.0.0.1 - - [22/Feb/2023:22:36:54 +0000] \"POST /jstor_harvester/do_task HTTP/1.1\" 200 87 \"-\" \"python-requests/2.25.1\"", "logger": "gunicorn.access", "level": "info", "timestamp": "2023-02-22T22:36:54.911829Z"}


if you see that then the component is writing to mongo, which you can also confirm in mongodb compass.

8) the itest should come back passing all tests- if it fails the aspace s3 it is because the aspace harvest did not harvest an expected file that the itest was looking for, but that is not relevant to this test.

9) stop the container with the `docker-compose -f docker-compose-local.yml down`  command.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? y

# Interested parties
Tag (@ mention) interested parties: @awoods 
