### PR TITLE
fix datestamps for mongo

### DIFF
--- a/app/jstor_harvester.py
+++ b/app/jstor_harvester.py
@@ -299,7 +299,8 @@ class JstorHarvester():
             if harvest_date == None: #set harvest date to today if harvest date is None
                 harvest_date = datetime.today().strftime('%Y-%m-%d') 
             harvest_date_obj = datetime.strptime(harvest_date, "%Y-%m-%d")
-            harvest_record = { "id": harvest_id, "harvest_date": harvest_date_obj, 
+            last_update = datetime.now()
+            harvest_record = { "id": harvest_id, "last_update": last_update, "harvest_date": harvest_date_obj, 
                 "repository_id": repository_id, "repository_name": repository_name, 
                 "total_harvest_count": total_harvested, "jobname": jobname, "success": success }
             harvest_collection = mongo_db[collection_name]
@@ -321,7 +322,8 @@ class JstorHarvester():
             if harvest_date == None: #set harvest date to today if harvest date is None
                 harvest_date = datetime.today().strftime('%Y-%m-%d')  
             harvest_date_obj = datetime.strptime(harvest_date, "%Y-%m-%d")
-            harvest_record = { "harvest_id": harvest_id, "last_update": harvest_date_obj, "record_id": record_id, 
+            last_update = datetime.now()
+            harvest_record = { "harvest_id": harvest_id, "last_update": last_update, "harvest_date": harvest_date_obj, "record_id": record_id, 
                 "repository_id": repository_id, "repository_name": repository_name, 
                 "status": status, "success": success, "error": err_msg }
             record_collection = mongo_db[collection_name]


### PR DESCRIPTION
**Fix timestamps.**
* * *

**JIRA Ticket**: [(link)](https://jira.huit.harvard.edu/browse/SS-253)

# What does this Pull Request do?
Fixes last_update mongo field to use now (not 0), to distinguish multiple harvests per day

# How should this be tested?

Deploy to dev
Run itest, should see now timestamps in mongo

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests?
- integration tests?

# Interested parties
Tag (@ mention) interested parties
