### PR TITLE
Ss 304

### DIFF
--- a/tests/invoke-task.py
+++ b/tests/invoke-task.py
@@ -4,4 +4,6 @@ app1 = Celery('tasks')
 app1.config_from_object('celeryconfig')
 
 # Send a simple task (create and send in 1 step)
-res = app1.send_task('tasks.tasks.do_task', args=[{"job_ticket_id":"123","jstorforum":True,"harvestset":"713","harvesttype":"full"}], kwargs={}, queue="harvest_jstorforum")
+#res = app1.send_task('tasks.tasks.do_task', args=[{"job_ticket_id":"123","jstorforum":True,"harvestset":"713","harvesttype":"full"}], kwargs={}, queue="harvest_jstorforum")
+#test for until, will result in only 1 rec
+res = app1.send_task('tasks.tasks.do_task', args=[{"job_ticket_id":"20230424A","jstorforum":True,"harvestset":"811","harvestdate":"2023-04-18", "until":"2023-04-20"}], kwargs={}, queue="harvest_jstorforum")

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -2,12 +2,14 @@ from dotenv import load_dotenv
 import os
 from pymongo import MongoClient
 from datetime import date, timedelta, datetime
+import pytest
 
 load_dotenv()
 
 harvestdate = date.today() - timedelta(days = 1)
 successdate = datetime(2023, 3, 7)
 
+@pytest.mark.skip(reason="test collection in mongo pending")
 def test_success_date():
 
     mongo_url = os.environ.get('MONGO_URL')
@@ -15,7 +17,7 @@ def test_success_date():
     mongo_client = MongoClient(mongo_url, maxPoolSize=1)
 
     mongo_db = mongo_client[mongo_dbname]
-    testcoll = mongo_db['jstor_harvest_summary_test']
+    testcoll = mongo_db['jstor_harvester_summary_test']
     rec = testcoll.find({"repository_id":"713", "success":True}, {"harvest_date":1}).sort("harvest_date", -1).limit(1)
     latest_mongo_success_date = rec[0]['harvest_date']
 


### PR DESCRIPTION
**recognize "until" oai verb**
* * *

**JIRA Ticket**: [(link)](https://jira.huit.harvard.edu/browse/SS-304)

# What does this Pull Request do?
Allows the use of the "until" verb for oai harvesting

# How should this be tested?

Deploy to dev (done)
with celery configured for dev, run:
> python3 tests/invoke_task.py
with this line uncommented:
res = app1.send_task('tasks.tasks.do_task', args=`[{"job_ticket_id":"20230424A","jstorforum":True,"harvestset":"811","harvestdate":"2023-04-18", "until":"2023-04-20"}], kwargs={}, queue="harvest_jstorforum")`

Find dev harvest log and you will see only 1 record was harvested (Done successfully)



# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests?
- integration tests?

# Interested parties
Tag (@ mention) interested parties
